### PR TITLE
chore(release): add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY build/distributions/ /plugins


### PR DESCRIPTION
Turns out we needed a simple Dockerfile for the release action.