### PR TITLE
Update to 23

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+      - name: set up java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: run tests
         run: ./gradlew test
       - name: build

--- a/.github/workflows/latestOrca.yml
+++ b/.github/workflows/latestOrca.yml
@@ -11,6 +11,10 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+      - name: set up java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: get dependency name to update
         id: dependency_name
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
 
+      - name: set up java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
       - name: run tests
         run: ./gradlew test
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,11 @@ spinnaker:
     plugins:
       Armory.PreConfiguredJobPlugin.RunScript:
         enabled: true
-        extensions:
-          armory.RunScriptPreConfiguredJobStage:
-            enabled: true
-            config:
-              account: kubernetes
-              credentials: kubernetes
-              artifactServiceUrl: http://spin-clouddriver.prod:7002
-              gitArtifactAccount: gitrepo
-            # Optional: override default init container image 
-              initContainerImage: myrepo/fetch-artifact:latest 
+        config:
+          account: kubernetes
+          credentials: kubernetes
+          artifactServiceUrl: http://spin-clouddriver.prod:7002
+          gitArtifactAccount: gitrepo
+        # Optional: override default init container image 
+          initContainerImage: myrepo/fetch-artifact:latest 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -3,19 +3,12 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
   }
 }
 
 plugins {
   id("io.spinnaker.plugin.bundler").version("$spinnakerGradleVersion")
   id("com.palantir.git-version").version("0.12.2")
-  id("org.jetbrains.kotlin.jvm").version("$kotlinVersion")
-  id("org.jetbrains.kotlin.kapt").version("$kotlinVersion")
-}
-
-repositories {
-  mavenCentral()
 }
 
 spinnakerBundle {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@ org.gradle.parallel=true
 
 pluginOwner=armory-io
 
-spinnakerGradleVersion=8.0.4
+spinnakerGradleVersion=8.10.0
 pf4jVersion=3.2.0
-korkVersion=7.56.0
-orcaVersion=8.11.0
+korkVersion=7.81.0
+orcaVersion=8.12.0
 kotlinVersion=1.3.72
 k8sClientVersion=5.0.0

--- a/run-script-plugin-orca/run-script-plugin-orca.gradle
+++ b/run-script-plugin-orca/run-script-plugin-orca.gradle
@@ -1,7 +1,10 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
+    }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
     }
 }
 
@@ -17,6 +20,9 @@ repositories {
     mavenCentral()
     jcenter()
     maven { url "http://dl.bintray.com/spinnaker/spinnaker/" }
+
+    // Used for testing against the Google product releases.
+    maven { url "https://spinnaker-releases.bintray.com/jars" }
 }
 
 spinnakerPlugin {
@@ -25,7 +31,6 @@ spinnakerPlugin {
 }
 
 dependencies {
-    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.11.3'
     compileOnly(group: 'org.pf4j', name: 'pf4j', version: "${pf4jVersion}") {
         exclude group: "org.slf4j"
     }

--- a/run-script-plugin-orca/src/main/kotlin/com/armory/plugin/preconfigured/PluginConfig.kt
+++ b/run-script-plugin-orca/src/main/kotlin/com/armory/plugin/preconfigured/PluginConfig.kt
@@ -1,8 +1,8 @@
 package com.armory.plugin.preconfigured
 
-import com.netflix.spinnaker.kork.plugins.api.ExtensionConfiguration
+import com.netflix.spinnaker.kork.plugins.api.PluginConfiguration
 
-@ExtensionConfiguration("armory.RunScriptPreConfiguredJobStage")
+@PluginConfiguration
 data class PluginConfig(
   var account: String?,
   var credentials: String?,


### PR DESCRIPTION
This PR is about migrate the plugin to the V2 plugin framework

- update Kork & Orca to latest
- update GHA for Java 11
- change configs to match V2 plugin
- rollback pluginSdk workaround

Now the spin services target to java 11.